### PR TITLE
Update Gradle, coroutines, Android sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ apply plugin: "kotlin-kapt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
-    compileSdk 30
+    compileSdk 31
 
     defaultConfig {
         applicationId "com.karumi"
         minSdk 21
-        targetSdk 30
+        targetSdk 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.TestRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = "1.0.5"
+        compose_version = "1.1.1"
         dagger_hilt_version = "2.38.1"
         coroutines_version = "1.4.3"
         accompanist_version = "0.11.1"
-        kotlin_version = "1.5.31"
+        kotlin_version = "1.6.10"
     }
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = "1.0.0-beta08"
-        dagger_hilt_version = "2.36"
+        compose_version = "1.0.5"
+        dagger_hilt_version = "2.38.1"
         coroutines_version = "1.4.3"
         accompanist_version = "0.11.1"
-        kotlin_version = "1.5.10"
+        kotlin_version = "1.5.31"
     }
     repositories {
         google()
@@ -13,10 +13,10 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.0-alpha02"
+        classpath "com.android.tools.build:gradle:7.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
-        classpath "com.karumi:shot:5.10.5"
+        classpath "com.karumi:shot:5.14.1"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_hilt_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jun 14 09:19:39 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Trying to update versions of the tools.

- Bumped targetSdk version to 31
- Updated compose to 1.1.1
- Updated hilt to 2.38.1
- Updated Shot to 5.14.1
- Updated Gradle and AGP

Let's see if CI passes, then decide if we go on with the Pull Request or we close it